### PR TITLE
Gateway module calling execute and compose

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,30 @@
+name: Build and Test
+
+on:
+  push:
+    branches: 
+      - *
+  pull_request:
+    branches: 
+      - *
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build
+    - run: npm test

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,12 +1,8 @@
 name: Build and Test
 
 on:
-  push:
-    branches: 
-      - *
-  pull_request:
-    branches: 
-      - *
+  - push
+  - pull_request
 
 jobs:
   build:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,10 +20,12 @@
                 "--colors",
                 "${workspaceFolder}/lambdacg-resolver/test/**/*.test.ts"
             ],
+            "runtimeArgs": ["--preserve-symlinks"],
             "internalConsoleOptions": "openOnSessionStart",
             "skipFiles": [
             "<node_internals>/**"
-            ]
+            ],
+            "smartStep": true
         }
     ]
 }

--- a/lambdacg-resolver/src/composer-contract.ts
+++ b/lambdacg-resolver/src/composer-contract.ts
@@ -1,0 +1,5 @@
+import { HandlerResponse } from 'lambdacg-contract';
+
+type ComposeFunction = (responseTemplate: HandlerResponse, responses: HandlerResponse[]) => HandlerResponse;
+
+export {ComposeFunction};

--- a/lambdacg-resolver/src/composer.ts
+++ b/lambdacg-resolver/src/composer.ts
@@ -1,14 +1,9 @@
 import _ from 'lodash';
-
+import { ComposeFunction } from './composer-contract';
 import { HandlerResponse } from 'lambdacg-contract';
 
 interface DictionaryObject {
     [key: string]: any
-}
-
-function compose(responseTemplate: HandlerResponse, responses: HandlerResponse[]): HandlerResponse
-{
-    return responses.reduce(mergeItems, responseTemplate); 
 }
 
 function mergeItems (item1: any, item2: any) {
@@ -66,6 +61,11 @@ function mergeObjects (object1: DictionaryObject, object2: DictionaryObject): Di
         }
     }
     return result;
+}
+
+const compose : ComposeFunction = (responseTemplate, responses) =>
+{
+    return responses.reduce(mergeItems, responseTemplate); 
 }
 
 export { compose };

--- a/lambdacg-resolver/src/executor-contract.ts
+++ b/lambdacg-resolver/src/executor-contract.ts
@@ -1,0 +1,11 @@
+import { HandlerResponse, HandlerFactory, HandlerParameters } from 'lambdacg-contract';
+
+type ExecuteAsyncFunction = (execution: string, handlerFactories : HandlerFactory[], requestName: string, requestParams: HandlerParameters) => Promise<HandlerResponse[]>;
+
+interface Executor {
+    execution: string;
+    startExecute(handlerFactories : HandlerFactory[], requestName: string, requestParams: HandlerParameters): (HandlerResponse | Promise<HandlerResponse>)[]
+    executeAsync(handlerFactories : HandlerFactory[], requestName: string, requestParams: HandlerParameters): Promise<HandlerResponse[]>;
+}
+
+export {ExecuteAsyncFunction, Executor};

--- a/lambdacg-resolver/src/executor.ts
+++ b/lambdacg-resolver/src/executor.ts
@@ -1,10 +1,6 @@
-import { HandlerFactory, HandlerParameters, HandlerResponse } from 'lambdacg-contract';
+import { HandlerFactory, HandlerParameters } from 'lambdacg-contract';
+import { ExecuteAsyncFunction, Executor} from './executor-contract';
 
-interface Executor {
-    execution: string;
-    startExecute(handlerFactories : HandlerFactory[], requestName: string, requestParams: HandlerParameters): (HandlerResponse | Promise<HandlerResponse>)[]
-    executeAsync(handlerFactories : HandlerFactory[], requestName: string, requestParams: HandlerParameters): Promise<HandlerResponse[]>;
-}
 
 class OptionalExecutor implements Executor {
     
@@ -57,7 +53,7 @@ const executorMap = executorClasses.reduce(
         return map;
     }, {});
 
-const executeAsync = function(execution: string, handlerFactories : HandlerFactory[], requestName: string, requestParams: HandlerParameters) : Promise<HandlerResponse[]>
+const executeAsync:ExecuteAsyncFunction = function(execution, handlerFactories, requestName, requestParams)
 {
     const executor = executorMap[execution];
     if ('object' !== typeof executor) {

--- a/lambdacg-resolver/src/gateway.ts
+++ b/lambdacg-resolver/src/gateway.ts
@@ -1,0 +1,67 @@
+import { ExecuteAsyncFunction } from './executor-contract';
+import { ComposeFunction } from './composer-contract';
+import { HandlerFactory } from 'lambdacg-contract';
+
+type GatewayRequest = {
+    execution?: string;
+    requestName: string;
+    requestParams?: any;
+    responseTemplate?: any;
+}
+
+type GatewaySuccessResponse = {
+    success: true;
+    response: any;
+}
+
+type GatewayErrorResponse = {
+    success: false;
+    error: any;
+}
+
+type GatewayResponse = GatewaySuccessResponse | GatewayErrorResponse;
+
+class Gateway {
+
+    #handlerFactories: HandlerFactory[]
+    #executeAsync: ExecuteAsyncFunction
+    #compose: ComposeFunction
+    
+    constructor(handlerFactories: HandlerFactory[], executeAsync: ExecuteAsyncFunction, compose: ComposeFunction) {
+        this.#handlerFactories = handlerFactories;
+        this.#executeAsync = executeAsync;
+        this.#compose = compose;
+    }
+
+    async handleRequestAsync(request: GatewayRequest):Promise<GatewayResponse> {
+        try {
+            const { 
+                execution: optionalExecution, 
+                requestName, 
+                requestParams: optionalRequestParams, 
+                responseTemplate: optionalResponseTemplate  
+            } = request;
+
+            const execution = optionalExecution ?? "all";
+            const responseTemplate = optionalResponseTemplate ?? {};
+            const requestParams = optionalRequestParams ?? {};
+
+            const responses = await this.#executeAsync(execution, this.#handlerFactories, requestName, requestParams);
+            
+            const response = this.#compose(responseTemplate, responses);
+    
+            return {
+                success: true,
+                response
+            };
+        } catch (error) {
+            return {
+                success: false,
+                error
+            };
+        }
+    }
+
+}
+
+export { Gateway, GatewayRequest, GatewayErrorResponse, GatewaySuccessResponse, GatewayResponse };

--- a/lambdacg-resolver/src/index.ts
+++ b/lambdacg-resolver/src/index.ts
@@ -8,6 +8,12 @@ import { AppSyncResolverEvent } from 'aws-lambda';
 const handlerFactories : HandlerFactory[] = require('./handlerFactories.json').map(require);
 const gateway = new Gateway(handlerFactories, executeAsync, compose);
 
+/**
+ * The following is a naïve implementation of a handler for appsync resolver events,
+ * only for illustrational purposes.
+ * Need som hands-on testing to find out if this will work. 
+ */
+
 function handleEventAsync (event : AppSyncResolverEvent<GatewayRequest,Record<string,any>>) : Promise<GatewayResponse>
 {
     return gateway.handleRequestAsync(event.arguments);

--- a/lambdacg-resolver/src/index.ts
+++ b/lambdacg-resolver/src/index.ts
@@ -1,42 +1,16 @@
-"use strict";
-
 import _ from 'lodash';
+import { Gateway, GatewayRequest, GatewayResponse } from './gateway';
 import { executeAsync } from './executor';
 import { compose } from './composer';
-import { HandlerFactory, HandlerParameters, HandlerResponse } from 'lambdacg-contract';
-
-
+import { HandlerFactory } from 'lambdacg-contract';
 import { AppSyncResolverEvent } from 'aws-lambda';
 
 const handlerFactories : HandlerFactory[] = require('./handlerFactories.json').map(require);
+const gateway = new Gateway(handlerFactories, executeAsync, compose);
 
-
-interface AppSyncEventArguments {
-    execution?: string;
-    requestName: string;
-    requestParams: HandlerParameters;
-    responseTemplate: HandlerResponse;
+function handleEventAsync (event : AppSyncResolverEvent<GatewayRequest,Record<string,any>>) : Promise<GatewayResponse>
+{
+    return gateway.handleRequestAsync(event.arguments);
 }
-    
-async function handleEvent (event : AppSyncResolverEvent<AppSyncEventArguments,Record<string,any>>)  {
 
-    const { execution: optionalExecution, requestName, requestParams, responseTemplate } = event.arguments;
-    const execution = optionalExecution ?? "all";
-
-    try {
-        const responses = await executeAsync(execution, handlerFactories, requestName, requestParams);
-        
-        const response = compose(responseTemplate, responses);
-
-        return {
-            response
-        };
-    } catch (error) {
-        return {
-            error
-        };
-    }
-};
-
-
-export { handleEvent };
+export { handleEventAsync };

--- a/lambdacg-resolver/test/gateway.test.ts
+++ b/lambdacg-resolver/test/gateway.test.ts
@@ -1,0 +1,135 @@
+import { expect} from "chai";
+import sinon from 'sinon';
+import { Gateway } from 'lambdacg-resolver/gateway';
+import { ComposeFunction } from 'lambdacg-resolver/composer-contract';
+import { ExecuteAsyncFunction } from 'lambdacg-resolver/executor-contract';
+import { HandlerFactory} from 'lambdacg-contract'
+
+describe("Gateway", () => {
+
+    it("Should call compose and execute", async () => {
+        const composeStub = sinon.stub().returns("composeResponse");
+        const compose: ComposeFunction = composeStub;
+
+        const executeAsyncStub = sinon.stub().returns(Promise.resolve(["executeResponse"]));
+        const executeAsync : ExecuteAsyncFunction = executeAsyncStub;
+
+        const handlerFactories: HandlerFactory[] = [];
+
+        const gateway = new Gateway(handlerFactories, executeAsync, compose);
+ 
+        const result = await gateway.handleRequestAsync({
+            execution: "execution",
+            requestName: "requestName",
+            requestParams: "requestParameters",
+            responseTemplate: "responseTemplate"
+        }); 
+
+        expect(result).to.be.deep.equal({success:true,response: "composeResponse"});
+        expect(executeAsyncStub.calledOnceWith("execution", handlerFactories, "requestName", "requestParameters")).to.be.true;
+        expect(composeStub.calledOnceWith("responseTemplate", ["executeResponse"])).to.be.true;
+    });
+
+    it("Should call compose and execute with non-supplied parameters", async () => {
+        const composeStub = sinon.stub().returns("composeResponse");
+        const compose: ComposeFunction = composeStub;
+
+        const executeAsyncStub = sinon.stub().returns(Promise.resolve(["executeResponse"]));
+        const executeAsync : ExecuteAsyncFunction = executeAsyncStub;
+
+        const handlerFactories: HandlerFactory[] = [];
+
+        const gateway = new Gateway(handlerFactories, executeAsync, compose);
+ 
+        const result = await gateway.handleRequestAsync({
+            requestName: "requestName"
+        }); 
+
+        expect(result).to.be.deep.equal({success:true,response: "composeResponse"});
+        expect(executeAsyncStub.calledOnceWith("all", handlerFactories, "requestName", {})).to.be.true;
+        expect(composeStub.calledOnceWith({}, ["executeResponse"])).to.be.true;
+    });
+
+    it("Should respond with the error that execute throws", async () => {
+        const composeStub = sinon.stub().returns("composeResponse");
+        const compose: ComposeFunction = composeStub;
+
+        const executeAsyncStub = sinon.stub().throws(new Error("executeAsyncError"));
+        const executeAsync : ExecuteAsyncFunction = executeAsyncStub;
+
+        const handlerFactories: HandlerFactory[] = [];
+
+        const gateway = new Gateway(handlerFactories, executeAsync, compose);
+ 
+        const result = await gateway.handleRequestAsync({
+            requestName: "requestName"
+        }); 
+
+        expect(result.success).to.be.false;
+        expect(executeAsyncStub.callCount == 1).to.be.true;
+        expect(composeStub.callCount == 0).to.be.true;
+
+        if (result.success === false) 
+        {
+            expect(result.error).to.be.a("Error");
+            const error = result.error as Error;
+            expect(error.message).to.be.equal("executeAsyncError");
+        }
+    });
+
+    it("Should respond with the error that execute rejects with", async () => {
+        const composeStub = sinon.stub().returns("composeResponse");
+        const compose: ComposeFunction = composeStub;
+
+        const executeAsyncStub = sinon.stub().returns(Promise.reject(new Error("executeAsyncError")));
+        const executeAsync : ExecuteAsyncFunction = executeAsyncStub;
+
+        const handlerFactories: HandlerFactory[] = [];
+
+        const gateway = new Gateway(handlerFactories, executeAsync, compose);
+ 
+        const result = await gateway.handleRequestAsync({
+            requestName: "requestName"
+        }); 
+
+        expect(result.success).to.be.false;
+        expect(executeAsyncStub.callCount == 1).to.be.true;
+        expect(composeStub.callCount == 0).to.be.true;
+
+        if (result.success === false) 
+        {
+            expect(result.error).to.be.a("Error");
+            const error = result.error as Error;
+            expect(error.message).to.be.equal("executeAsyncError");
+        }
+    });
+
+    it("Should respond with the error that compose throws", async () => {
+        const composeStub = sinon.stub().throws(new Error("composeError"));
+        const compose: ComposeFunction = composeStub;
+
+        const executeAsyncStub = sinon.stub().returns(Promise.resolve(["executeResponse"]));
+        const executeAsync : ExecuteAsyncFunction = executeAsyncStub;
+
+        const handlerFactories: HandlerFactory[] = [];
+
+        const gateway = new Gateway(handlerFactories, executeAsync, compose);
+ 
+        const result = await gateway.handleRequestAsync({
+            requestName: "requestName"
+        }); 
+
+        expect(result.success).to.be.false;
+        expect(executeAsyncStub.callCount == 1).to.be.true;
+        expect(composeStub.callCount == 1).to.be.true;
+
+        if (result.success === false) 
+        {
+            expect(result.error).to.be.a("Error");
+            const error = result.error as Error;
+            expect(error.message).to.be.equal("composeError");
+        }
+    });
+   
+
+})

--- a/lambdacg-updater/src/package.json
+++ b/lambdacg-updater/src/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "lambdacg-updater",
   "devDependencies": {
     "aws-sdk": "^2.1013.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "lambdacg",
   "scripts": {
     "prepare": "npm-run-all prepare:*",
     "prepare:contract": "cd lambdacg-contract/src && npm ci",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
     "prepare": "npm-run-all prepare:*",
-    "prepare:contract": "cd lambdacg-contract/src && npm install",
-    "prepare:resolver": "cd lambdacg-resolver/src && npm install",
+    "prepare:contract": "cd lambdacg-contract/src && npm ci",
+    "prepare:resolver": "cd lambdacg-resolver/src && npm ci",
 
     "build": "npm run build:contract && npm run build:resolver",
     "build:contract": "cd lambdacg-contract/src && npm run build",


### PR DESCRIPTION
lambdacg-resolver: moved the logic of calling executeAsync and compose to a separate module, gateway.ts. The handler for appsync now only has a few lines; this will also make it easier to create handlers for different scenarios.